### PR TITLE
Mouse clickthrough

### DIFF
--- a/SessionTracker/Controls/EntriesContainer.cs
+++ b/SessionTracker/Controls/EntriesContainer.cs
@@ -63,7 +63,14 @@ namespace SessionTracker.Controls
 
         public override Control TriggerMouseInput(MouseEventType mouseEventType, MouseState ms)
         {
-            if (_settingService.RootPanelIgnoresMouseInput.Value && !(GameService.Input.Keyboard.ActiveModifiers == ModifierKeys.Alt))
+            
+            if (
+                !_settingService.DragWindowWithMouseIsEnabledSetting.Value &&
+                (
+                    _settingService.RootPanelIgnoresMouseInput.Value && 
+                    !(GameService.Input.Keyboard.ActiveModifiers == ModifierKeys.Alt)
+                )
+            )
             {
                 return null;
             }

--- a/SessionTracker/Controls/EntriesContainer.cs
+++ b/SessionTracker/Controls/EntriesContainer.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Blish_HUD;
 using Blish_HUD.Controls;
+using Blish_HUD.Input;
 using Blish_HUD.Modules.Managers;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
 using SessionTracker.Controls.Hint;
 using SessionTracker.Models;
 using SessionTracker.Services;
@@ -57,6 +59,15 @@ namespace SessionTracker.Controls
             GameService.Overlay.UserLocaleChanged                        -= OnUserChangedLanguageInBlishSettings;
 
             base.DisposeControl();
+        }
+
+        public override Control TriggerMouseInput(MouseEventType mouseEventType, MouseState ms)
+        {
+            if (_settingService.RootPanelIgnoresMouseInput.Value && !(GameService.Input.Keyboard.ActiveModifiers == ModifierKeys.Alt))
+            {
+                return null;
+            }
+            return base.TriggerMouseInput(mouseEventType, ms);
         }
 
         public void ToggleVisibility()

--- a/SessionTracker/Settings/SettingEntries/SettingService.cs
+++ b/SessionTracker/Settings/SettingEntries/SettingService.cs
@@ -61,6 +61,12 @@ namespace SessionTracker.Settings.SettingEntries
                       "at that point Blish does not know " +
                       "which API key it should use. You have to log into a character first.");
 
+            RootPanelIgnoresMouseInput = settings.DefineSetting(
+                "mouse clickthrough",
+                false,
+                () => "mouse clickthrough (read tooltip)",
+                () => "the stats window will ignore all mouse input unless the ALT keyboard key is held down");
+
             WindowIsVisibleOnWorldMapSetting = settings.DefineSetting(
                 "show window on world map",
                 true,
@@ -193,6 +199,7 @@ namespace SessionTracker.Settings.SettingEntries
         public SettingEntry<int> FontSizeIndexSetting { get; }
         public SettingEntry<bool> SessionValuesAreVisibleSetting { get; }
         public SettingEntry<bool> TotalValuesAreVisibleSetting { get; }
+        public SettingEntry<bool> RootPanelIgnoresMouseInput { get; }
         public SettingEntry<bool> WindowIsVisibleOnCharacterSelectAndLoadingScreensAndCutScenesSetting { get; }
         public SettingEntry<bool> WindowIsVisibleOnWorldMapSetting { get; }
         public SettingEntry<bool> WindowIsVisibleOutsideOfWvwAndSpvpSetting { get; }

--- a/SessionTracker/Settings/Window/GeneralSettingsTabView.cs
+++ b/SessionTracker/Settings/Window/GeneralSettingsTabView.cs
@@ -30,6 +30,7 @@ namespace SessionTracker.Settings.Window
             ControlFactory.CreateSetting(generalSectionFlowPanel, buildPanel.Width, _settingService.SessionValuesAreVisibleSetting);
             ControlFactory.CreateSetting(generalSectionFlowPanel, buildPanel.Width, _settingService.TotalValuesAreVisibleSetting);
             ControlFactory.CreateSetting(generalSectionFlowPanel, buildPanel.Width, _settingService.DragWindowWithMouseIsEnabledSetting);
+            ControlFactory.CreateSetting(generalSectionFlowPanel, buildPanel.Width, _settingService.RootPanelIgnoresMouseInput);
             ControlFactory.CreateSetting(generalSectionFlowPanel, buildPanel.Width, _settingService.CornerIconIsVisibleSetting);
             ControlFactory.CreateSetting(generalSectionFlowPanel, buildPanel.Width, _settingService.CoinDisplayFormatSetting);
             ControlFactory.CreateSetting(generalSectionFlowPanel, buildPanel.Width, _settingService.HideStatsWithValueZeroSetting);


### PR DESCRIPTION
Added boolean setting for mouse clickthrough on stats ui. Presented under mouse drag setting.
Added `TriggerMouseEvent` override on EntriesContainer. Prevents all mouse input when clickthrough is enabled and drag is not. Temporary bypass by holding the ALT key.